### PR TITLE
fix: multicall shared cache and abi mismatch

### DIFF
--- a/moc_prices_source/evm.py
+++ b/moc_prices_source/evm.py
@@ -280,7 +280,7 @@ class Address(str):
             if len(addr) != 40:
                 raise ValueError('addr has less o more than 40 digits')
 
-        addr = '0x' + addr.lower()
+        addr = Web3.to_checksum_address('0x' + addr.lower())
 
         return super().__new__(cls, addr)
 
@@ -466,7 +466,7 @@ class Call:
     
     @property
     def as_tuple(self):
-        return (self.to_as_str, self.data_as_str)
+        return (self.to_as_str, self.data)
 
     def __repr__(self):
         return (f"Call(to={repr(self.to_as_str)}, "
@@ -489,6 +489,7 @@ class Multicall():
             raise ValueError('Invalid RPC URI or Web3 object or EVM object')
         self.web3: Web3 = self.evm.web3
         self.address = Address(address)
+        self._already_been_executed_once = {}
         self.clear_calls()
 
     def clear_calls(self):
@@ -912,8 +913,6 @@ class Multicall():
                 fn_spec = extra['fn_spec']
                 result = fn_spec.decode_outputs(raw_result)
             self._calls[call]['data'][namespace] = result
-
-    _already_been_executed_once = {}
 
     def reset_executed_once(self, namespace: Optional[str] = None):
         self._already_been_executed_once[namespace] = False   


### PR DESCRIPTION
This PR fixes 2 issues:

* The evm.py multicall 'cache' was class level so both mainnet and testnet formulas had a key collision. A cache key is supported, but seems intended to prevent collisions within the same Multicall instance, not globally.

* An abi mismatch on multicall 2 which resulted in this error:

``` Coinpair ISLIQ_FLIP(test):
  ABI Not Found!
  Found 1 element(s) named `tryBlockAndAggregate` that accept 2 argument(s).
  The provided arguments are not valid.
  Provided argument types: (bool,(address,str),(address,str))
  Provided keyword argument types: {}

  Tried to find a matching ABI element named `tryBlockAndAggregate`, but encountered the
  following problems:
  Signature: tryBlockAndAggregate(bool,(address,bytes)[]), type: function
  Argument 1 value `False` is valid.
  Argument 2 value `(('0xfe8ff2959DcF922f5A3F7F9cD305b75ADab0a485',
  'dd77653f000000000000000000000000000000000000000000000000000000000000002000000000000000000000
  000000000000000000000000000000000000000000020000000000000000000000000000000000000000000000000
  00000000000004000000000000000000000000000000000000000000000000000000000000000a000000000000000
  000000000000000000000000000000000000000000000000020000000000000000000000000000000000000000008
  7abe3dcba4e1e02e0dcfa00000000000000000000000000000000000000000144e7a2563e83094fff68a400000000
  000000000000000000000000000000000000000000000000000000020000000000000000000000000000000000000
  00000000052266456490292a6080000000000000000000000000000000000000000000000c4bb673ab58d629c23')
  , ('0xfe8ff2959DcF922f5A3F7F9cD305b75ADab0a485',
  '4ae4c0b7000000000000000000000000000000000000000000000000000000000000002000000000000000000000
  000000000000000000000000000000000000000000020000000000000000000000000000000000000000000000000
  00000000000004000000000000000000000000000000000000000000000000000000000000000a000000000000000
  000000000000000000000000000000000000000000000000020000000000000000000000000000000000000000008
  7abe3dcba4e1e02e0dcfa00000000000000000000000000000000000000000144e7a2563e83094fff68a400000000
  000000000000000000000000000000000000000000000000000000020000000000000000000000000000000000000
  00000000052266456490292a6080000000000000000000000000000000000000000000000c4bb673ab58d629c23')
  )` is not compatible with type `(address,bytes)[]`.
```